### PR TITLE
🔀 :: 에러 핸들링 세팅

### DIFF
--- a/src/main/kotlin/baegteun/post/global/error/ErrorCode.kt
+++ b/src/main/kotlin/baegteun/post/global/error/ErrorCode.kt
@@ -1,0 +1,9 @@
+package baegteun.post.global.error
+
+import com.fasterxml.jackson.annotation.JsonFormat
+
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+enum class ErrorCode(val status: Int, val message: String) {
+
+}

--- a/src/main/kotlin/baegteun/post/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/baegteun/post/global/error/ErrorResponse.kt
@@ -1,0 +1,4 @@
+package baegteun.post.global.error
+
+class ErrorResponse {
+}

--- a/src/main/kotlin/baegteun/post/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/baegteun/post/global/error/ErrorResponse.kt
@@ -1,4 +1,6 @@
 package baegteun.post.global.error
 
-class ErrorResponse {
-}
+data class ErrorResponse(
+    val status: Int,
+    val message: String
+)

--- a/src/main/kotlin/baegteun/post/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/baegteun/post/global/error/GlobalExceptionHandler.kt
@@ -1,0 +1,29 @@
+package baegteun.post.global.error
+
+import baegteun.post.global.error.exception.PaperException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(PaperException::class)
+    fun handleGlobalException(e: PaperException): ResponseEntity<ErrorResponse?> {
+        val errorCode: ErrorCode = e.errorCode
+        return ResponseEntity(
+            ErrorResponse(status = errorCode.status, message = errorCode.message),
+            HttpStatus.valueOf(errorCode.status)
+        )
+    }
+
+    @ExceptionHandler(BindException::class)
+    fun bindException(e: BindException): ResponseEntity<*> {
+        val errorMap: MutableMap<String, String?> = HashMap()
+        for (error in e.fieldErrors) {
+            errorMap[error.field] = error.defaultMessage
+        }
+        return ResponseEntity<Map<String, String?>>(errorMap, HttpStatus.BAD_REQUEST)
+    }
+}

--- a/src/main/kotlin/baegteun/post/global/error/exception/PaperException.kt
+++ b/src/main/kotlin/baegteun/post/global/error/exception/PaperException.kt
@@ -1,0 +1,4 @@
+package baegteun.post.global.error.exception
+
+class PaperException {
+}

--- a/src/main/kotlin/baegteun/post/global/error/exception/PaperException.kt
+++ b/src/main/kotlin/baegteun/post/global/error/exception/PaperException.kt
@@ -1,4 +1,7 @@
 package baegteun.post.global.error.exception
 
-class PaperException {
-}
+import baegteun.post.global.error.ErrorCode
+
+class PaperException(
+    val errorCode: ErrorCode
+): RuntimeException()


### PR DESCRIPTION
- 편하게 관리하기 위해 ErrorCode enum 정의
- 400대 response에게 body를 주기 위해 ErrorResponse data class 정의
- RestController 또는 validation 에서 exception이 일어나면 핸들링하도록 GlobalExceptionHandler